### PR TITLE
restructure and break content into concise sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,62 +17,61 @@
       W3C Workshop on Web &amp; Virtual Reality
     </h1>
     <p>
-      October 2016, 19-20, San Jose, CA, USA
+      October 19-20, 2016; San Jose, CA, USA
     </p>
     <ul class="menu">
       <li>
-        <a href="#top">Intro</a> <!-- <li><a href="agenda">Agenda</a> -->
-         <!-- <li><a href="report">Report</a> -->
+        <a href="#goals">Goals</a>
       </li>
       <li>
-        <a href="#participate">How to Participate</a>
+        <a href="#attend">How to Attend</a>
       </li>
       <li>
-        <a href="#logistics">Logistics</a>
+        <a href="#location">Location</a>
       </li>
       <li>
         <a href="#program">Program Committee</a>
       </li>
-      <!-- <li><a href="submissions/Overview.html">Submissions</a></li> -->
       <!--<li><a href="#schedule">Workshop Schedule</a></li>-->
-      <!-- <li><a href="http://www.w3.org/2016/04/annotation/report.html">Workshop Report</a></li> -->
     </ul>
     <aside class="box" id="dates">
       <h2 class="footnote">
         Important Dates
       </h2>
       <dl>
-        <dt class="">
-          23 September 2016:
+        <dt>
+          September 23, 2016:
         </dt>
         <dd>
           <a href=
           "https://www.w3.org/2002/09/wbs/1/vr-workshop/">Registration</a> and
           <a href="#position-statements">position statements</a> deadline
         </dd>
-        <dt class="">
-          30 September 2016:
+        <dt>
+          September 30, 2016:
         </dt>
         <dd>
-          Acceptance notifications
+          Acceptance notification emails
         </dd>
-        <dt class="">
-          5 October 2016:
+        <dt>
+          October 5, 2016:
         </dt>
         <dd>
-          <a href="#schedule">Program announced</a>
+          <!-- <a href="#schedule">Program announced</a> -->
+          Program announced
         </dd>
-        <dt class="">
-          12 October 2016:
+        <dt>
+          October 12, 2016:
         </dt>
         <dd>
           Participants confirmed
         </dd>
-        <dt class="">
-          19-20 October 2016:
+        <dt>
+          October 19-20, 2016:
         </dt>
         <dd>
-          <a href="#schedule">Workshop</a>
+          <!-- <a href="#schedule">Workshop</a> -->
+          Workshop
         </dd>
       </dl>
     </aside>
@@ -82,10 +81,10 @@
         and position statements
       </h2>
       <p>
-        Fill out the <b><a href=
-        "https://www.w3.org/2002/09/wbs/1/vr-workshop/">registration
-        form</a></b> or submit a <a href="#position-statements">position
-        statement</a>
+        Fill out the <a href=
+        "https://www.w3.org/2002/09/wbs/1/vr-workshop/"><b>registration
+        form</b></a> or submit a <a href="#position-statements">position
+        statement</a>.
       </p>
       <!-- <p><a href="submissions/">Submitted position</a> statements are available.</p> -->
     </aside>
@@ -117,221 +116,121 @@
         <a href="#sponsorship">Become a sponsor!</a>
       </p>
       <p>
-        <a href="sponsorship.html">Sponsorship package info</a>
+        <a href="sponsorship.html">Sponsorship package info.</a>
       </p>
     </aside>
     <section>
+      <h2 id="goals">
+        What is the purpose of this workshop?
+      </h2>
+      <p>The primary goal of the workshop is to bring together practitioners of Web and Virtual Reality technologies to make the Open Web Platform a better delivery mechanism for VR experiences.</p>
+      <p>The secondary goals of the workshop are as follows:</p>
+      <ul>
+        <li>Share experiences between practitioners in VR and related fields.</li>
+        <li>Discuss how to solve for VR use cases that are difficult or impossible today on the Web.</li>
+        <li>Identify potential future standards and establish timelines to enable the Web to be a successful VR platform.</li>
+      </ul>
       <p>
-        A combination of improvements in hardware and software capabilities has
-        resulted in a renewed interest in virtual reality experiences. Many of
-        these improved capabilities are supported in modern browsers via the
-        Open Web Platform, and the Web provides a promising preexisting
-        ecosystem for creating, distributing and experiencing virtual reality
-        content, applications, and services.
+        We won't just be listening to presentations, but we will be actively participating in breakout sessions and working discussions covering <a href="#topics">topics</a> including but not limited to the current <a href="https://w3c.github.io/webvr/">WebVR API</a>. (To learn more information about WebVR, you may visit <a href="https://webvr.info">WebVR.info</a> and read the <a href="https://w3c.github.io/webvr/">Editor&#39;s Draft of the WebVR specification</a>.)
       </p>
-      <p>
-        This ability to build upon an existing ecosystem is all the more
-        important because the virtual reality industry is accelerating the
-        development of a new generation of gear, tools, and solutions for the
-        production, distribution and experiencing of VR. We can leverage the
-        strengths of the Open Web Platform to provide an interoperable
-        alternative to avoid fragmentation and duplicated effort.
-      </p>
-      <p>
-        The free and open distribution system of the Open Web Platform has
-        progressive enhancement at its core, provides the widest pre-existing
-        user base, and has a long track record of working successfully with all
-        kinds of users, including those with very specific requirements. The
-        Web itself can benefit from the new possibilities that ubiquitous
-        Virtual Reality brings: from improved core 3D graphics and media
-        capabilities to tight integration with immersive sensors, and on to new
-        ways of discovering and interacting with information and services.
-      </p>
-      <p>
-        This W3C workshop is to look at the intersection of Web and Virtual
-        Reality ideas and technologies. The workshop aims at enabling the
-        sharing of experiences between practitioners in these and related
-        fields, at encouraging discussion about existing gaps in the Open Web
-        Platform that may make some Virtual Reality use cases difficult or
-        impossible today, and at exploring what future standards are needed to
-        pave the way for the Web to be one of the major platforms for Virtual
-        Reality.
-      </p>
+      <h3 id="why-the-web">
+        How is the Web a viable platform for VR?
+      </h3>
+      <p>The Web provides a promising preexisting ecosystem for the creation, distribution, and experiencing of VR content, applications, and services.</p>
+      <p>In leveraging the Open Web Platform, we hope to provide an interoperability to avoid fragmentation and duplicated effort.</p>
+      <h3 id="why-vr">
+        Why does the Web platform need VR?
+      </h3>
+      <p>The Web can benefit from the the new possibilities offered by ubiquitous VR from improved 3D graphics and media capabilities to tight integration with immersive sensors, and on to new ways of discovering and interacting with content and services.</p>
     </section>
     <section>
-      <h3 id="participate">
-        Want to attend? Have something insightful to share?
-      </h3>
+      <h2 id="attend">
+        How can I attend?
+      </h2>
       <p>
-        We currently have a limit of only 100 attendees at the workshop. We
-        want to fill the room with people with practical experience of both Web
-        and Virtual Reality technologies. We won't just be listening to
-        presentations, but will be actively participating in topic breakouts
-        and working discussions.
+        Attendance is <b>free</b> for all invited participants and is open to the public, whether or not W3C members.
       </p>
       <p>
-        If you want to participate, please fill out the <b><a href=
-        "https://www.w3.org/2002/09/wbs/1/vr-workshop/">registration
-        form</a></b>. The registration is open to the public, whether or not
-        W3C members. Your participation is confirmed with an acceptance
-        notification (see <a href="#dates">important dates</a>). Since the
-        participation is limited, you must receive an acceptance notification
-        to be eligible to participate. Attendance is free for all participants.
+        If you wish to express interest in attending, please fill out the <a href="https://www.w3.org/2002/09/wbs/1/vr-workshop/"><b>registration form</b></a>. We want to fill the room with people with practical experience of both Web and VR technologies.
+      </p>
+      <p>
+        Because the venue can accommodate unfortunately only 100 attendees, you must receive an acceptance email in order to attend. Also, be sure to keep an eye on <a href="#dates"><b>these important dates</b></a>.
+      </p>
+      <p>
         As an alternative to the registration form, you are encouraged to
-        submit a <a href="#position-statements">position statement</a>.
+        submit a topic in the form of a <a href="#position-statements"><b>position statement</b></a>.
+      </p>
+      <p>Our aim is to get a diversity of attendees from a variety of industries and communities, including:</p>
+      <ul>
+        <li>VR hardware vendors</li>
+        <li>VR platform providers</li>
+        <li>VR content producers and distributors</li>
+        <li>VR software developers, preferably with experience in developing for Web browsers</li>
+        <li>VR experience designers</li>
+        <li>users of VR, especially in fields beyond entertainment</li>
+        <li>experts in challenges and opportunities of VR for people with disabilities</li>
+        <li>browser vendors</li>
+      </ul>
+      <h2 id="topics">
+        Which topics will be covered?
+      </h2>
+      <p>
+        We will cover important issues and architectural aspects of bringing VR experiences to the Web.
       </p>
       <p>
-        This is a workshop, not a conference, and any presentations will be
-        short, with topics suggested by participants at registration time and
-        decided by the chairs and program committee. Our goal is to actively
-        discuss topics, not to watch presentations.
-      </p>
-      <h4 id="topics">
-        Workshop topics
-      </h4>
-      <p>
-        The workshop will prioritize contributions on the larger-scale issues
-        and architectural aspect of bringing VR experiences to the Web but we
-        also welcome contributions that address specific issues and solutions.
-      </p>
-      <p>
-        Possible topics include, but are not limited to the following:
+        The tentative list of topics is as follows:
       </p>
       <ul>
-        <li>displaying stereoscopic content
-        </li>
-        <li>detecting &amp; adapting to characteristics of VR headsets
-        </li>
-        <li>handling new and heterogeneous input methods for VR (gamepad, hand
-        position, etc.) and how applications can handle the wide variety expected
-        on the Web
-        </li>
-        <li>accessible user interfaces and interoperability considerations
-        across VR applications
-        </li>
-        <li>innovative VR applications that provide novel accessibility
-        supports
-        </li>
-        <li>3D audio
-        </li>
-        <li>3D media synchronization
-        </li>
-        <li>declarative 3D scenes and 3D scene graph APIs
-        </li>
-        <li>interoperable formats and codecs for 3D and 360 content
-        </li>
-        <li>displaying and interacting with 360 video and images from HTML
-        </li>
-        <li>bringing VR as progressive enhancement to classic Web browsing
-        </li>
-        <li>3D video capture (3D camera) and processing (e.g., scene perception)
-        </li>
-        <li>streaming 3D/360 content, streaming real-time 3D content
-        </li>
-        <li>obstacles to high framerate rendering of 3D and better support for
-        low-latency input, processing, and rendering in the Web context
-        </li>
-        <li>intersection of needs for VR &amp; AR in the Web Platform (note that AR
-        is not the main focus of the workshop, but the Program Committee will
-        consider papers that provide insights on how the two fields overlap in
-        the context of the Web Platform)
-        </li>
-        <li>Performance: client side rendering perf, and bandwidth perf</li>
-        <li>Open and web friendly file formats, codecs and containers for WebVR</li>
-      </ul><!--      <h5 id="out-of-scope">Out of Scope</h5>
-      <ul>
-      </ul>-->
+        <li>displaying stereoscopic content</li>
+        <li>detecting and adapting to characteristics of VR headsets</li>
+        <li>handling new and varied input methods for VR (e.g., gamepad, hand position, etc.)</li>
+        <li>accessible user interfaces and interoperability considerations across VR applications</li>
+        <li>innovative VR applications that provide novel accessibility supports</li>
+        <li>3D audio</li>
+        <li>3D media synchronization</li>
+        <li>declarative 3D scenes and 3D scene-graph APIs</li>
+        <li>interoperable formats and codecs for 3D and 360&deg; content</li>
+        <li>displaying and interacting with 360&deg; video and images from HTML</li>
+        <li>bringing VR as progressive enhancement to classic Web browsing</li>
+        <li>3D video capture (3D camera) and processing (e.g., scene perception)</li>
+        <li>streaming 3D/360&deg; content, streaming real-time 3D content</li>
+        <li>obstacles to high-framerate rendering of 3D and better support for low-latency input, processing, and rendering</li>
+        <li>intersection of needs for VR &amp; AR in the Web Platform (note that AR is not the main focus of the workshop, but the Program Committee will consider topics that provide insights on how the two fields overlap in the context of the Web Platform)</li>
+        <li>performance of client-side rendering and bandwidth</li>
+        <li>open and Web-friendly file formats, codecs, and containers for VR</li>
+      </ul>
       <p>
         Suggestions for further workshop topics? Submit a <a href=
-        "https://github.com/w3c/vr-workshop/">pull request on GitHub</a>, or
+        "https://github.com/w3c/vr-workshop/">pull request on GitHub</a> or
         email Dominique Hazael-Massieux &lt;<a href=
         "mailto:dom@w3.org@w3.org">dom@w3.org</a>&gt;.
       </p>
-      <h4 id="position-statements">
-        Position statements
-      </h4>
+      <h2 id="position-statements">
+        How can I suggest a presentation?
+      </h2>
       <p>
-        A position statement is not required to attend (you can fill out the
-        <a href="https://www.w3.org/2002/09/wbs/1/vr-workshop/">registration
-        form</a> instead), but it does help set the topic discussions and to
-        establish a particular point of view. If you wish, you can send us a
-        position statement at <a href=
-        "mailto:team-vr-submission@w3.org">&lt;team-vr-submission@w3.org&gt;</a>
-        by the deadline (see <a href="#dates">important dates</a>). Our program
-        committee will review the input provided, and select the most relevant
-        topics and perspectives.
+        This is a workshop, not a conference, and any presentations will be short, with topics suggested by submissions and decided by the chairs and program committee. Our goal is to actively discuss topics, not to watch presentations.
       </p>
       <p>
-        A good position statement should be a few paragraphs (between 500 and
-        1000 words) and should include:
+        In order to best facilitate informed discussion, we encourage attendees to read the accepted topics prior to attending the workshop.
+      </p>
+      <p>
+        If you wish to present on a topic, you can send us a position statement at &lt;<a href="mailto:team-vr-submission@w3.org">team-vr-submission@w3.org</a>&gt; by the deadline (see <a href="#dates"><b>important dates</b></a>). Our <a href="committee">program committee</a> will review the input provided, and select the most relevant topics and perspectives.
+      </p>
+      <p>
+        A good position statement should be a few paragraphs (between 500 and 1000 words) and should include:
       </p>
       <ul>
-        <li>Your background in the intersection of Virtual Reality and Web
-        technologies.
-        </li>
-        <li>Which topic you would like to lead discussion on.
-        </li>
-        <li>Links to related supporting resources.
-        </li>
-        <li>Any other topics you think the workshop should cover in order to be
-        effective.
-        </li>
-        <li>A focus on technical issues, not process or platform preference. We
-        plan to talk about the <b>what</b>, not the <b>how</b>.
-        </li>
-      </ul>
-      <p>
-        Position statements must be in English, preferably in HTML or
-        plain-text format; images should be included inline in HTML using
-        base64-encoded data URIs. You may include multiple topics, but we ask
-        that each person submit only a single coherent position statement. The
-        input provided at registration time (bio, goals, interests) will be
-        published and linked to from this workshop page.
-      </p>
-      <h4 id="who-attend">
-        Who Should Attend
-      </h4>
-      <p>
-        Attendance is open to all, and our aim is to get a diversity of
-        attendees from a variety of industries and communities, including:
-      </p>
-      <ul>
-        <li>VR hardware (headsets, graphic &amp; audio cards, handle, cameras, etc.)
-        vendors,
-        </li>
-        <li>VR platform providers,
-        </li>
-        <li>VR content producers and distributors (including media companies),
-        </li>
-        <li>VR software developers, preferably with an experience in developing
-        for Web browsers,
-        </li>
-        <li>VR experience designers,
-        </li>
-        <li>Users of VR, especially in fields beyond entertainment,
-        </li>
-        <li>Experts in challenges and opportunities of VR for people with
-        disabilities,
-        </li>
-        <li>Browser vendors.
-        </li>
+        <li>Your background in the intersection of Web and Virtual Reality technologies.</li>
+        <li>Which topic you would like to lead discussion on.</li>
+        <li>Links to related supporting resources.</li>
+        <li>Any other topics you think the workshop should cover in order to be effective.</li>
+        <li>A focus on technical issues, not process or platform preference. We plan to talk about the <b>what</b>, not the <b>how</b>.</li>
+        <li>Position statements must be in English, preferably in HTML or plain-text format; images should be included inline in HTML using base64-encoded data URIs. You may include multiple topics, but we ask that each person submit only a single coherent position statement. The input provided at registration time (e.g., bio, goals, interests) will be published and linked to from this workshop page.</li>
       </ul>
     </section>
     <section>
-      <h3 id="goals">
-        Goals
-      </h3>
-      <p>
-        The primary goal of the workshop is to bring practitioners of Web and
-        Virtual Reality technologies together to make the Open Web Platform a
-        better delivery mechanism for Virtual Reality experiences.
-      </p>
-      <p>
-        The secondary goal of the workshop is to identify opportunities and
-        timelines for assisting the industry through facilitating
-        standardization efforts.
-      </p>
-      <h3 id="w3c">
+      <h2 id="w3c">
         What is W3C?
       </h3>
       <p>
@@ -345,12 +244,12 @@
       </p>
     </section>
     <section>
-      <h2 id="logistics">
-        Logistics
+      <h2 id="location">
+        Location
       </h2>
       <p>
-        The W3C Workshop on Web &amp; Virtual Reality is located at the Samsung
-        Semiconductor facilities in San Jose, CA.
+        The W3C Workshop on Web &amp; Virtual Reality is located at the <a href="https://www.google.com/maps/place/3665+First+St,+San+Jose,+CA+95134/">Samsung
+        Semiconductor facilities in San Jose, CA, USA</a>.
       </p>
       <h3 id="venue">
         Venue
@@ -399,9 +298,9 @@
         Chairs
       </h4>
       <ul>
-        <li>Anssi Kostiainen, Intel
+        <li><a href="https://twitter.com/anssik">Anssi Kostiainen</a> (<a href="http://www.intel.com/">Intel</a>)
         </li>
-        <li>Chris Van Wiemeersch, Mozilla
+        <li><a href="https://twitter.com/cvanw">Chris Van Wiemeersch</a> (<a href="https://www.mozilla.org/">Mozilla</a>)
         </li>
       </ul>
       <h4>
@@ -411,23 +310,23 @@
         (in progress)
       </p>
       <ul>
-        <li>Daniel Appelquist, Samsung
+        <li><a href="https://twitter.com/torgo">Daniel Appelquist</a> (<a href="http://www.samsung.com/">Samsung</a>)
         </li>
-        <li>Laszlo Gombos, Samsung
+        <li><a href="https://twitter.com/laszlogombos">Laszlo Gombos</a> (<a href="http://www.samsung.com/">Samsung</a>)
         </li>
-        <li>Dominique Hazaël-Massieux, W3C
+        <li><a href="https://twitter.com/dontcallmeDOM">Dominique Hazaël-Massieux</a> (<a href="https://www.w3.org/">W3C</a>)
         </li>
-        <li>Brandon Jones, Google
+        <li><a href="https://twitter.com/Tojiro">Brandon Jones</a> (<a href="https://www.google.com/">Google</a>)
         </li>
-        <li>Megan Lindsay, Google
+        <li><a href="https://www.linkedin.com/in/meganbateslindsay">Megan Lindsay</a> (<a href="https://www.google.com/">Google</a>)
         </li>
-        <li>Tony Parisi, Wevr
+        <li><a href="https://twitter.com/auradeluxe">Tony Parisi</a> (<a href="http://wevr.com/">Wevr</a>)
         </li>
-        <li>Philipp Slusallek, DFKI
+        <li><a href="https://graphics.cg.uni-saarland.de/slusallek/">Philipp Slusallek</a> (<a href="https://www.dfki.de/">DFKI</a>)
         </li>
-        <li>Jeff Sonstein, R.I.T.
+        <li><a href="https://twitter.com/jeffsonstein">Jeff Sonstein</a> (<a href="http://www.rit.edu/">RIT</a>)
         </li>
-        <li>Olivier Thereaux, BBC
+        <li><a href="https://twitter.com/olivierthereaux">Olivier Thereaux</a> (<a href="http://www.bbc.com/">BBC</a>)
         </li>
       </ul>
     </section><!--    <section>
@@ -479,8 +378,8 @@
         <p>
           Whether your interests are focused on a particular topic being
           discussed by a Working Group, or you wish to reach a diverse
-          international audience setting W3C's strategic direction, sponsorship
-          helps your organization reach W3C's engaged participants.
+          international audience setting W3C&#39;s strategic direction, sponsorship
+          helps your organization reach W3C&#39;s engaged participants.
         </p>
         <p>
           Sponsorships offset a portion of our meeting costs, so W3C welcomes
@@ -488,7 +387,7 @@
           subject to W3C approval.
         </p>
         <p>
-          If you're interested in being a sponsor of the W3C Web &amp; Virtual
+          If you&#39;re interested in being a sponsor of the W3C Web &amp; Virtual
           Reality Workshop, please contact J. Alan Bird, Global Business
           Development Leader, at &lt;<a href=
           "mailto:abird@w3.org">abird@w3.org</a>&gt; or +1 617 253 7823.

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -24,7 +24,7 @@
 
 
       <section>
-        <h4 id="why">Why Sponsor This Workshop?</h4>
+        <h3 id="why">Why Sponsor This Workshop?</h3>
         <p>The cost to hold a workshop includes costs for venue (including setup and custodial costs), AV requirements (optionally including recording), catering (lunch and breaks), materials, travel and staffing, and other considerations.</p>
 
         <p>Most of the planning, coordination, agenda building, and writing outcome reports are done for no cost by W3C staff or volunteers. But without sponsorships, W3C cannot hold workshops.</p>
@@ -93,9 +93,9 @@
       <article>
         <h3 id="sponsorship">Becoming a Sponsor</h3>
         <p>W3C Workshops, meetups, and other events bring you into direct contact with leading Web technology experts: representatives from industry, research, government, and the developer community.</p>
-        <p>Whether your interests are focused on a particular topic being discussed by a Working Group, or you wish to reach a diverse international audience setting W3C's strategic direction, sponsorship helps your organization reach W3C's engaged participants.</p>
+        <p>Whether your interests are focused on a particular topic being discussed by a Working Group, or you wish to reach a diverse international audience setting W3C&#39;s strategic direction, sponsorship helps your organization reach W3C&#39;s engaged participants.</p>
         <p>Sponsorships offset a portion of our meeting costs, so W3C welcomes multiple sponsors for each event. All proposals for sponsorship are subject to W3C approval.</p>
-        <p>If you're interested in being a sponsor of the W3C Web &amp; Virtual Reality Workshop, please contact J. Alan Bird, Global Business Development Leader, at &lt;<a href="mailto:abird@w3.org">abird@w3.org</a>&gt; or +1 617 253 7823.</p>
+        <p>If you&#39;re interested in being a sponsor of the W3C Web &amp; Virtual Reality Workshop, please contact J. Alan Bird, Global Business Development Leader, at &lt;<a href="mailto:abird@w3.org">abird@w3.org</a>&gt; or +1 617 253 7823.</p>
         <p>For additional information, please visit the <a href="http://www.w3.org/Consortium/sponsor/events#workshop">W3C sponsorship program</a>.</p>
       </article>
     </section>


### PR DESCRIPTION
(Part of this is based off of my other PR, #6.) I've heard a lot of confusion from folks in regards to what this workshop is about and how they attend. I adjusted the content to include the essentials and rearranged the content into sections with FAQ-style headings. I think it reads quite well, but I'd love to hear people's thoughts.

I pushed a copy of the changes to my fork's GitHub Pages so folks can preview it:
https://cvan.io/vr-workshop/
https://cvan.io/vr-workshop/sponsorship.html

And, for measure:
https://w3c.github.io/vr-workshop/
https://w3c.github.io/vr-workshop/sponsorship.html
